### PR TITLE
Remove paybalance dark-gray background

### DIFF
--- a/OLX - Quite Dark.css
+++ b/OLX - Quite Dark.css
@@ -437,7 +437,6 @@
     background: #191919; }
 
   .paybalance-box {
-    background: #191919;
     border-color: #303030;
     /* #ededed */ }
 


### PR DESCRIPTION
This one removes dark-gray background from paybalance box.
And another update: RO is not Russian Federation, is Romania.